### PR TITLE
Fixing error when you pass 2 xcoms fromprevious task

### DIFF
--- a/airflow/dags/launcher/launcher.py
+++ b/airflow/dags/launcher/launcher.py
@@ -58,7 +58,7 @@ class ContainerLauncher:
         if xcoms is None or xcoms == [] or xcoms == () or xcoms == (None,):
             return {}
         elif len(xcoms) == 1:
-            return dict(xcoms)
+            return dict(xcoms[0])
 
         result = {}
         egible_xcoms = (d for d in xcoms if d is not None and len(d) > 0)


### PR DESCRIPTION
Ran into problems when I was passing 1 xcom variable after sending two the previous task and looked into things and this was my fix.. A tuple was trying to be converted to a dictionary where it should have been just the first thing in the tuple.. 