### PR TITLE
ability to send environment variables from the UI

### DIFF
--- a/airflow/dags/launcher/launcher.py
+++ b/airflow/dags/launcher/launcher.py
@@ -26,9 +26,14 @@ class ContainerLauncher:
     def run(self, **context):
         log.info(f"Creating image {self.image_name}")
 
-        environment = {
-            'EXECUTION_ID': (context['dag_run'].run_id)
-        }
+       # get environment variables from UI
+        try:
+            environment = Variable.get(self.image_name, deserialize_json=True)
+        except:
+            environment = dict()
+
+        environment['EXECUTION_ID'] = (context['dag_run'].run_id)
+        
         args_json_escaped = self._pull_all_parent_xcoms(context)
         container: Container = self.cli.containers.run(detach=True, image=self.image_name, environment=environment,
                                             command=args_json_escaped)


### PR DESCRIPTION
Send environment variables using the Variables tab in the UI to send them to containers at runtime. Save one or more environment variables in a JSON like object in the UI with a key corresponding to the task they belong to. 
# Example:
Task Name: Task1
Environment Variables expected in the container:
Foo1, Foo2

UI Settings:
Key: Task1
Value:  {"Foo1" : "Bar1", "Foo2" : "Bar2"}